### PR TITLE
Align identity metadata and profile image signals

### DIFF
--- a/public/ai-profile.json
+++ b/public/ai-profile.json
@@ -1,6 +1,7 @@
 {
   "name": "Priyanshu Chawda",
   "url": "https://priyanshuworks.tech",
+  "image": "https://avatars.githubusercontent.com/u/86182776?v=4",
   "description": "AI-focused software engineer from Pune, India building LLM workflows, MCP tools, typed APIs, evals, developer tools, local-first AI systems, and production-grade AI web applications.",
   "location": "Pune, India",
   "role": "AI-focused Software Engineer",

--- a/src/__tests__/seo.test.ts
+++ b/src/__tests__/seo.test.ts
@@ -100,6 +100,12 @@ describe('SEO indexing contract', () => {
     });
   });
 
+  test('uses the canonical entity name in Open Graph site metadata', () => {
+    const metadata = buildMetadata(pageMetadata.about);
+
+    expect(metadata.openGraph?.siteName).toBe(siteConfig.name);
+  });
+
   test('uses one canonical origin in sitemap and robots', () => {
     const entries = sitemap();
     const robotsTxt = robots();
@@ -176,6 +182,9 @@ describe('SEO indexing contract', () => {
   test('keeps person schema fields populated', () => {
     expect(personStructuredData.name).toBe(siteConfig.name);
     expect(personStructuredData.url).toBe(siteConfig.url);
+    expect(siteConfig.profileImage).toMatch(/^https:\/\//);
+    expect(personStructuredData.image).toBe(siteConfig.profileImage);
+    expect(personStructuredData.image).not.toContain('/opengraph-image');
     expect(personStructuredData.jobTitle).toBe(siteConfig.jobTitle);
     expect(personStructuredData.knowsAbout.length).toBeGreaterThan(0);
     expect(personStructuredData.alumniOf.name).toBe(
@@ -329,6 +338,7 @@ describe('SEO indexing contract', () => {
     expect(llmsText).toContain('improve code quality');
 
     expect(aiProfile.keyPages).toContain(codeauditProjectUrl);
+    expect(aiProfile.image).toBe(siteConfig.profileImage);
     expect(aiProfile.projects).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -60,7 +60,7 @@ export const metadata: Metadata = {
     url: '/',
     title: siteConfig.title,
     description: siteConfig.description,
-    siteName: `${siteConfig.name} Portfolio`,
+    siteName: siteConfig.name,
   },
   twitter: {
     card: 'summary_large_image',

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -43,7 +43,7 @@ export function buildMetadata({
       url: path,
       title,
       description,
-      siteName: `${siteConfig.name} Portfolio`,
+      siteName: siteConfig.name,
       images: [ogImage],
     },
     twitter: {

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -15,6 +15,7 @@ export const siteConfig = {
   twitter: 'https://x.com/priyanshuchawda',
   github: 'https://github.com/priyanshuchawda',
   linkedin: 'https://www.linkedin.com/in/priyanshuchawda',
+  profileImage: 'https://avatars.githubusercontent.com/u/86182776?v=4',
   lastUpdated: '2026-05-17',
   keywords: [
     'Priyanshu Chawda',

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -23,7 +23,7 @@ export const personStructuredData = {
   name: siteConfig.name,
   url: siteConfig.url,
   email: siteConfig.email,
-  image: `${siteConfig.url}/opengraph-image`,
+  image: siteConfig.profileImage,
   jobTitle: siteConfig.jobTitle,
   description: siteConfig.description,
   sameAs: sameAsLinks,


### PR DESCRIPTION
Closes #10.

## What changed

- Added a shared crawlable profile image URL to `siteConfig`.
- Updated Person JSON-LD to use the profile image instead of the generated OG card.
- Added the profile image to `ai-profile.json`.
- Aligned Open Graph `siteName` with the canonical entity/site name.
- Added regression tests for profile-image and site-name consistency.

## Validation

- `pnpm lint`
- `pnpm test` (37 tests passed)
- `pnpm build`
- Profile image HEAD request: `200 image/jpeg`
- Built home JSON-LD check confirmed the updated `Person.image` URL