### PR TITLE
Add DeepSource analyzer config for TypeScript quality checks

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,23 @@
+version = 1
+
+exclude_patterns = [
+  ".next/**",
+  "coverage/**",
+  "node_modules/**",
+]
+
+test_patterns = [
+  "src/__tests__/**",
+  "**/*.test.ts",
+  "**/*.test.tsx",
+]
+
+[[analyzers]]
+name = "javascript"
+enabled = true
+
+  [analyzers.meta]
+  plugins = ["react"]
+  environment = ["nodejs", "browser", "vitest"]
+  module_system = "es-modules"
+  dialect = "typescript"

--- a/src/__tests__/quality.test.ts
+++ b/src/__tests__/quality.test.ts
@@ -1,0 +1,21 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+describe('Repository quality tooling', () => {
+  test('keeps DeepSource configured for the TypeScript app stack', () => {
+    const configPath = join(process.cwd(), '.deepsource.toml');
+
+    expect(existsSync(configPath)).toBe(true);
+
+    const config = readFileSync(configPath, 'utf8');
+
+    expect(config).toContain('version = 1');
+    expect(config).toMatch(/\[\[analyzers\]\]\s+name = "javascript"/);
+    expect(config).toContain('plugins = ["react"]');
+    expect(config).toContain('environment = ["nodejs", "browser", "vitest"]');
+    expect(config).toContain('"src/__tests__/**"');
+    expect(config).toContain('"node_modules/**"');
+    expect(config).toContain('".next/**"');
+  });
+});


### PR DESCRIPTION
Closes #12.

## What changed

- Added root `.deepsource.toml` so DeepSource can activate from the default branch.
- Enabled the JavaScript analyzer for the Next.js/React/TypeScript stack.
- Marked Vitest test files and excluded generated/dependency output.
- Added a lightweight regression test to keep the DeepSource config present and stack-aligned.

## Validation

- `pnpm lint`
- `pnpm test` (38 tests passed)
- `pnpm build`

## Notes

The PR that adds `.deepsource.toml` may still show the existing DeepSource missing-config error because DeepSource requires the config to be present on the default branch. After this PR is merged, follow-up PRs should be able to read the committed config.