### PR TITLE
Add route-specific OG images for projects and writing

### DIFF
--- a/src/__tests__/seo.test.ts
+++ b/src/__tests__/seo.test.ts
@@ -5,7 +5,16 @@ import nextConfig from '../../next.config';
 import manifest from '@/app/manifest';
 import robots from '@/app/robots';
 import sitemap from '@/app/sitemap';
+import {
+  dynamicParams as projectImageDynamicParams,
+  generateStaticParams as generateProjectImageStaticParams,
+} from '@/app/projects/[slug]/opengraph-image';
 import { generateMetadata as generateProjectMetadata } from '@/app/projects/[slug]/page';
+import {
+  dynamicParams as writingImageDynamicParams,
+  generateStaticParams as generateWritingImageStaticParams,
+} from '@/app/writing/[slug]/opengraph-image';
+import { generateMetadata as generateWritingMetadata } from '@/app/writing/[slug]/page';
 import { pageMetadata } from '@/data/seo';
 import { buildMetadata } from '@/lib/metadata';
 import { sameAsLinks, siteConfig } from '@/lib/site';
@@ -27,6 +36,20 @@ import aiProfile from '../../public/ai-profile.json';
 const MIN_META_DESCRIPTION_LENGTH = 25;
 const MAX_META_DESCRIPTION_LENGTH = 160;
 const codeauditProjectUrl = `${siteConfig.url}/projects/codeaudit`;
+
+function getMetadataImageUrl(images: unknown) {
+  const firstImage = Array.isArray(images) ? images[0] : images;
+
+  if (typeof firstImage === 'string') {
+    return firstImage;
+  }
+
+  if (firstImage && typeof firstImage === 'object' && 'url' in firstImage) {
+    return String(firstImage.url);
+  }
+
+  return undefined;
+}
 
 function expectValidMetaDescription(label: string, description: string) {
   expect(description, `${label} should not be empty`).toBeTruthy();
@@ -273,6 +296,12 @@ describe('SEO indexing contract', () => {
 
     expect(metadata.alternates?.canonical).toBe('/projects/codeaudit');
     expect(metadata.openGraph?.url).toBe('/projects/codeaudit');
+    expect(getMetadataImageUrl(metadata.openGraph?.images)).toBe(
+      '/projects/codeaudit/opengraph-image',
+    );
+    expect(getMetadataImageUrl(metadata.twitter?.images)).toBe(
+      '/projects/codeaudit/opengraph-image',
+    );
     expect(metadata.title).toEqual({
       absolute: 'CodeAudit MCP | AI Code Audit Server',
     });
@@ -288,6 +317,32 @@ describe('SEO indexing contract', () => {
         'npm MCP server',
         'skills CLI codeaudit',
       ]),
+    );
+  });
+
+  test('writing page metadata uses route-specific generated images', async () => {
+    const post = writingPosts[0];
+    const metadata = await generateWritingMetadata({
+      params: Promise.resolve({ slug: post.slug }),
+    });
+    const expectedImagePath = `/writing/${post.slug}/opengraph-image`;
+
+    expect(getMetadataImageUrl(metadata.openGraph?.images)).toBe(
+      expectedImagePath,
+    );
+    expect(getMetadataImageUrl(metadata.twitter?.images)).toBe(
+      expectedImagePath,
+    );
+  });
+
+  test('generated social image routes are bounded to known slugs', () => {
+    expect(projectImageDynamicParams).toBe(false);
+    expect(writingImageDynamicParams).toBe(false);
+    expect(generateProjectImageStaticParams()).toEqual(
+      projects.map((project) => ({ slug: project.slug })),
+    );
+    expect(generateWritingImageStaticParams()).toEqual(
+      writingPosts.map((post) => ({ slug: post.slug })),
     );
   });
 

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,75 +1,22 @@
 import { ImageResponse } from 'next/og';
 import { siteConfig } from '@/lib/site';
+import { SocialImageCard, socialImageSize } from '@/lib/social-image';
 
+/** Accessible fallback text for the default portfolio social image. */
 export const alt = `${siteConfig.name} - AI Engineer Portfolio`;
-export const size = {
-  width: 1200,
-  height: 630,
-};
+/** Pixel dimensions for the default portfolio social image. */
+export const size = socialImageSize;
+/** MIME type returned by the generated social image endpoint. */
 export const contentType = 'image/png';
 
+/** Render the default portfolio social sharing image. */
 export default function Image() {
   return new ImageResponse(
-    <div
-      style={{
-        background: '#050505',
-        color: '#ededed',
-        display: 'flex',
-        flexDirection: 'column',
-        height: '100%',
-        justifyContent: 'space-between',
-        padding: '72px',
-        width: '100%',
-      }}
-    >
-      <div
-        style={{
-          color: '#3b82f6',
-          fontSize: 30,
-          fontWeight: 700,
-          letterSpacing: 0,
-        }}
-      >
-        AI-focused software engineer / Agentic systems / Developer tools
-      </div>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
-        <div
-          style={{
-            fontSize: 88,
-            fontWeight: 800,
-            letterSpacing: 0,
-            lineHeight: 1,
-          }}
-        >
-          {siteConfig.name}
-        </div>
-        <div
-          style={{
-            color: '#a3a3a3',
-            fontSize: 38,
-            lineHeight: 1.25,
-            maxWidth: 900,
-          }}
-        >
-          Building MCP servers, LLM workflows, automation systems, and
-          full-stack AI applications.
-        </div>
-      </div>
-      <div
-        style={{
-          alignItems: 'center',
-          borderTop: '1px solid #262626',
-          color: '#ededed',
-          display: 'flex',
-          fontSize: 28,
-          justifyContent: 'space-between',
-          paddingTop: 28,
-        }}
-      >
-        <span>{siteConfig.url.replace('https://', '')}</span>
-        <span style={{ color: '#3b82f6' }}>priyanshu_</span>
-      </div>
-    </div>,
+    <SocialImageCard
+      eyebrow="AI-focused software engineer / Agentic systems / Developer tools"
+      title={siteConfig.name}
+      description="Building MCP servers, LLM workflows, automation systems, and full-stack AI applications."
+    />,
     size,
   );
 }

--- a/src/app/projects/[slug]/opengraph-image.tsx
+++ b/src/app/projects/[slug]/opengraph-image.tsx
@@ -1,0 +1,40 @@
+import { ImageResponse } from 'next/og';
+import { getProjectBySlug, projects } from '@/data/projects';
+import { siteConfig } from '@/lib/site';
+import { SocialImageCard, socialImageSize } from '@/lib/social-image';
+
+/** Restrict generated project social images to known project slugs. */
+export const dynamicParams = false;
+/** Pixel dimensions for project social images. */
+export const size = socialImageSize;
+/** MIME type returned by generated project social image endpoints. */
+export const contentType = 'image/png';
+
+/** Prebuild social images for every known project route. */
+export function generateStaticParams() {
+  return projects.map((project) => ({ slug: project.slug }));
+}
+
+/** Render a project-specific Open Graph image. */
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const project = getProjectBySlug(slug);
+
+  if (!project) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  return new ImageResponse(
+    <SocialImageCard
+      eyebrow={`${project.subtitle} / ${siteConfig.name}`}
+      title={project.title}
+      description={project.summary}
+      footer={`${siteConfig.url.replace('https://', '')}/projects/${slug}`}
+    />,
+    size,
+  );
+}

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -39,6 +39,8 @@ export async function generateMetadata({
     description: project.metaDescription,
     path: `/projects/${project.slug}`,
     type: 'article',
+    imagePath: `/projects/${project.slug}/opengraph-image`,
+    imageAlt: project.metaTitle,
     keywords: [
       project.title,
       project.subtitle,

--- a/src/app/writing/[slug]/opengraph-image.tsx
+++ b/src/app/writing/[slug]/opengraph-image.tsx
@@ -1,0 +1,46 @@
+import { ImageResponse } from 'next/og';
+import {
+  getWritingPath,
+  getWritingPostBySlug,
+  writingPosts,
+} from '@/data/writing';
+import { siteConfig } from '@/lib/site';
+import { SocialImageCard, socialImageSize } from '@/lib/social-image';
+
+/** Restrict generated writing social images to known article slugs. */
+export const dynamicParams = false;
+/** Pixel dimensions for writing social images. */
+export const size = socialImageSize;
+/** MIME type returned by generated writing social image endpoints. */
+export const contentType = 'image/png';
+
+/** Prebuild social images for every known writing route. */
+export function generateStaticParams() {
+  return writingPosts.map((post) => ({ slug: post.slug }));
+}
+
+/** Render an article-specific Open Graph image. */
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const post = getWritingPostBySlug(slug);
+
+  if (!post) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  const writingPath = getWritingPath(post.slug);
+
+  return new ImageResponse(
+    <SocialImageCard
+      eyebrow={`${post.tags.join(' / ')} / ${post.readingTime}`}
+      title={post.title}
+      description={post.summary}
+      footer={`${siteConfig.url.replace('https://', '')}${writingPath}`}
+    />,
+    size,
+  );
+}

--- a/src/app/writing/[slug]/page.tsx
+++ b/src/app/writing/[slug]/page.tsx
@@ -40,6 +40,8 @@ export async function generateMetadata({
     description: post.metaDescription,
     path: getWritingPath(post.slug),
     type: 'article',
+    imagePath: `${getWritingPath(post.slug)}/opengraph-image`,
+    imageAlt: post.metaTitle,
   });
 }
 

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -7,23 +7,29 @@ export function buildMetadata({
   path,
   type = 'website',
   keywords,
+  imagePath,
+  imageAlt,
 }: {
   title: string;
   description: string;
   path: string;
   type?: 'website' | 'article';
   keywords?: readonly string[];
+  imagePath?: string;
+  imageAlt?: string;
 }): Metadata {
+  const ogImagePath = imagePath ?? '/opengraph-image';
+  const twitterImagePath = imagePath ?? '/twitter-image';
   const ogImage = {
-    url: '/opengraph-image',
+    url: ogImagePath,
     width: 1200,
     height: 630,
-    alt: title,
+    alt: imageAlt ?? title,
   };
 
   const twitterImage = {
-    url: '/twitter-image',
-    alt: title,
+    url: twitterImagePath,
+    alt: imageAlt ?? title,
   };
 
   return {

--- a/src/lib/social-image.tsx
+++ b/src/lib/social-image.tsx
@@ -1,0 +1,86 @@
+import { siteConfig } from './site';
+
+/** Standard Open Graph image dimensions used across generated social cards. */
+export const socialImageSize = {
+  width: 1200,
+  height: 630,
+} as const;
+
+/** Shared visual layout for generated portfolio, project, and writing cards. */
+export function SocialImageCard({
+  eyebrow,
+  title,
+  description,
+  footer = siteConfig.url.replace('https://', ''),
+  badge = 'priyanshu_',
+}: {
+  eyebrow: string;
+  title: string;
+  description: string;
+  footer?: string;
+  badge?: string;
+}) {
+  return (
+    <div
+      style={{
+        background: '#050505',
+        color: '#ededed',
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        justifyContent: 'space-between',
+        padding: '72px',
+        width: '100%',
+      }}
+    >
+      <div
+        style={{
+          color: '#3b82f6',
+          fontSize: 30,
+          fontWeight: 700,
+          letterSpacing: 0,
+          lineHeight: 1.2,
+        }}
+      >
+        {eyebrow}
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+        <div
+          style={{
+            fontSize: 82,
+            fontWeight: 800,
+            letterSpacing: 0,
+            lineHeight: 0.98,
+            maxWidth: 980,
+          }}
+        >
+          {title}
+        </div>
+        <div
+          style={{
+            color: '#a3a3a3',
+            fontSize: 36,
+            lineHeight: 1.25,
+            maxWidth: 940,
+          }}
+        >
+          {description}
+        </div>
+      </div>
+      <div
+        style={{
+          alignItems: 'center',
+          borderTop: '1px solid #262626',
+          color: '#ededed',
+          display: 'flex',
+          fontSize: 28,
+          justifyContent: 'space-between',
+          paddingTop: 28,
+        }}
+      >
+        <span>{footer}</span>
+        <span style={{ color: '#3b82f6' }}>{badge}</span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #14.

## What changed

- Added a reusable generated social image card renderer.
- Kept the root OG image behavior while moving the shared visual layout into `src/lib/social-image.tsx`.
- Added dynamic project and writing `opengraph-image` routes.
- Updated project and writing metadata to use route-specific image URLs for Open Graph and Twitter cards.
- Added regression tests proving project and writing metadata no longer use the generic image path.

## Validation

- `pnpm lint`
- `pnpm test` (39 tests passed)
- `pnpm build`
- Local production route checks:
  - `/projects/codeaudit/opengraph-image` -> `200 image/png`
  - `/projects/workaudit-ai/opengraph-image` -> `200 image/png`
  - `/writing/what-are-mcp-servers/opengraph-image` -> `200 image/png`