### PR TITLE
[codex] Fix Search Console URL variants

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -32,8 +32,29 @@ const nextConfig: NextConfig = {
   async redirects() {
     return [
       {
+        source: '/:path*',
+        has: [
+          {
+            type: 'host',
+            value: 'www.priyanshuworks.tech',
+          },
+        ],
+        destination: 'https://priyanshuworks.tech/:path*',
+        permanent: true,
+      },
+      {
         source: '/projects/reposentinel-mcp',
         destination: '/projects/codeaudit',
+        permanent: true,
+      },
+      {
+        source: '/projects/gemma_control',
+        destination: '/projects/gemma-control',
+        permanent: true,
+      },
+      {
+        source: '/projects/screen_recorder',
+        destination: '/projects/screen-recorder',
         permanent: true,
       },
     ];

--- a/src/__tests__/seo.test.ts
+++ b/src/__tests__/seo.test.ts
@@ -526,4 +526,50 @@ describe('SEO indexing contract', () => {
       ]),
     );
   });
+
+  test('redirects duplicate hosts and legacy project slugs to canonical project URLs', async () => {
+    const redirects =
+      typeof nextConfig.redirects === 'function'
+        ? await nextConfig.redirects()
+        : [];
+    const sitemapUrls = sitemap().map((entry) => entry.url);
+
+    expect(redirects).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: '/:path*',
+          destination: `${siteConfig.url}/:path*`,
+          permanent: true,
+          has: [
+            expect.objectContaining({
+              type: 'host',
+              value: 'www.priyanshuworks.tech',
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          source: '/projects/gemma_control',
+          destination: '/projects/gemma-control',
+          permanent: true,
+        }),
+        expect.objectContaining({
+          source: '/projects/screen_recorder',
+          destination: '/projects/screen-recorder',
+          permanent: true,
+        }),
+      ]),
+    );
+    expect(sitemapUrls).not.toContain(
+      `${siteConfig.url}/projects/gemma_control`,
+    );
+    expect(sitemapUrls).not.toContain(
+      `${siteConfig.url}/projects/screen_recorder`,
+    );
+    expect(sitemapUrls).not.toContain(
+      `${siteConfig.url}/projects/reposentinel-mcp`,
+    );
+    sitemapUrls.forEach((url) => {
+      expect(url).not.toContain('www.priyanshuworks.tech');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Redirect `www.priyanshuworks.tech` to the canonical apex domain.
- Redirect GitHub-style underscore project slugs to the canonical hyphen slugs.
- Add SEO regression coverage to keep redirected variants out of the sitemap.

Closes #18

## Validation
- pnpm test
- pnpm lint
- pnpm build
- Local redirect checks:
  - `/projects/gemma_control` -> `/projects/gemma-control`
  - `/projects/screen_recorder` -> `/projects/screen-recorder`
  - `Host: www.priyanshuworks.tech` -> `https://priyanshuworks.tech/:path*`