### PR TITLE
[Fix mobile header navigation

### DIFF
--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { SiteHeader } from '@/components/SiteHeader';
+import { mainNav } from '@/data/navigation';
+
+describe('SiteHeader', () => {
+  test('opens mobile navigation and exposes all main routes', () => {
+    render(<SiteHeader />);
+
+    const menuButton = screen.getByRole('button', {
+      name: 'Open navigation menu',
+    });
+    expect(menuButton.getAttribute('aria-expanded')).toBe('false');
+    expect(
+      screen.queryByRole('navigation', { name: 'Mobile navigation' }),
+    ).toBeNull();
+
+    fireEvent.click(menuButton);
+
+    const mobileNav = screen.getByRole('navigation', {
+      name: 'Mobile navigation',
+    });
+    expect(
+      screen
+        .getByRole('button', { name: 'Close navigation menu' })
+        .getAttribute('aria-expanded'),
+    ).toBe('true');
+
+    mainNav.forEach((item) => {
+      const link = within(mobileNav).getByRole('link', { name: item.label });
+      expect(link.getAttribute('href')).toBe(item.href);
+    });
+  });
+
+  test('closes mobile navigation after selecting a route', () => {
+    render(<SiteHeader />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Open navigation menu' }),
+    );
+    const projectsLink = within(
+      screen.getByRole('navigation', { name: 'Mobile navigation' }),
+    ).getByRole('link', { name: 'Projects' });
+
+    projectsLink.addEventListener('click', (event) => event.preventDefault(), {
+      once: true,
+    });
+    fireEvent.click(projectsLink);
+
+    expect(
+      screen.queryByRole('navigation', { name: 'Mobile navigation' }),
+    ).toBeNull();
+    expect(
+      screen
+        .getByRole('button', { name: 'Open navigation menu' })
+        .getAttribute('aria-expanded'),
+    ).toBe('false');
+  });
+});

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,9 +1,15 @@
+'use client';
+
 import Link from 'next/link';
+import { Menu, X } from 'lucide-react';
+import { useState } from 'react';
 import { mainNav } from '@/data/navigation';
 import { siteConfig } from '@/lib/site';
 import { GithubIcon, LinkedinIcon } from './SocialIcons';
 
 export function SiteHeader() {
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+
   return (
     <header className="border-border bg-background/50 fixed top-0 right-0 left-0 z-40 border-b backdrop-blur-md">
       <nav
@@ -27,7 +33,7 @@ export function SiteHeader() {
             </Link>
           ))}
         </div>
-        <div className="flex gap-4">
+        <div className="flex items-center gap-3">
           <a
             href={siteConfig.github}
             target="_blank"
@@ -46,8 +52,44 @@ export function SiteHeader() {
           >
             <LinkedinIcon className="h-5 w-5" />
           </a>
+          <button
+            type="button"
+            aria-label={
+              mobileNavOpen ? 'Close navigation menu' : 'Open navigation menu'
+            }
+            aria-controls="mobile-navigation"
+            aria-expanded={mobileNavOpen}
+            onClick={() => setMobileNavOpen((open) => !open)}
+            className="border-border text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-accent inline-flex h-10 w-10 items-center justify-center rounded-md border transition-colors focus-visible:ring-2 focus-visible:outline-none md:hidden"
+          >
+            {mobileNavOpen ? (
+              <X className="h-5 w-5" aria-hidden="true" />
+            ) : (
+              <Menu className="h-5 w-5" aria-hidden="true" />
+            )}
+          </button>
         </div>
       </nav>
+      {mobileNavOpen ? (
+        <nav
+          id="mobile-navigation"
+          aria-label="Mobile navigation"
+          className="border-border bg-background absolute inset-x-0 top-full border-b shadow-lg md:hidden"
+        >
+          <div className="container mx-auto grid gap-1 px-6 py-4">
+            {mainNav.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                onClick={() => setMobileNavOpen(false)}
+                className="hover:bg-muted focus-visible:ring-accent rounded-md px-3 py-3 text-sm font-semibold transition-colors focus-visible:ring-2 focus-visible:outline-none"
+              >
+                {item.label}
+              </Link>
+            ))}
+          </div>
+        </nav>
+      ) : null}
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- Add a mobile-only header menu button so visitors can navigate on phone screens.
- Render the full main navigation inside an accessible mobile dropdown.
- Close the mobile menu after selecting a route.
- Add regression tests for mobile nav open/close behavior and route links.

## Validation
- pnpm test
- pnpm lint
- pnpm build
- Playwright mobile production-server check at 390x844:
  - menu button visible
  - desktop Projects link hidden on mobile
  - mobile menu exposes Home, About, Projects, Services, Writing, Achievements, Contact
  - clicking Projects navigates to /projects and closes the menu